### PR TITLE
Pull image if exists rather than exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Heavily integrated with AWS. Use in tandem with the Buildkite ECR plugin.
 steps:
   - command: "export VAR=123"
   - plugins:
-      - futrli/buildtools#v0.1.0:
+      - futrli/buildtools#v0.2.0:
           task: build
           aws-account-id: "111111111111"
           build-args:

--- a/hooks/command
+++ b/hooks/command
@@ -37,7 +37,7 @@ set +e
 
     while IFS= read -rd '' token; do
         [[ -n "$token" ]] && run_params+=("$token")
-    done < <(xargs printf '%s\0' <<< "${BUILDKITE_COMMAND}")
+    done < <(xargs printf '%s\0' <<< "${BUILDKITE_COMMAND:-}")
 
     echo "+++ :docker: Running command >&2"
     exec "${run_params[@]}"

--- a/tasks/build.bash
+++ b/tasks/build.bash
@@ -53,8 +53,8 @@ done <<< "$(plugin_read_list BUILD_ARGS)"
 image_matching_tag_count=$(aws_check_image "${image_name}" "${aws_account_id}" "${tag}")
 
 if [[ ${image_matching_tag_count} -gt 0 ]] ; then
-    echo "+++ Tag ${tag} already exists on ECR. Will not continue to build."
-    exit 0
+    echo "Pulling existing image prior to build"
+    run_docker pull "${full_image_tag}"
 fi
 
 


### PR DESCRIPTION
This will allow images to be rebuilt rather than exiting if the image already exists.

Also fixes an issue with $BUILDKITE_COMMAND being undefined when it's being parsed by making the env var fall back to an empty string if not set.